### PR TITLE
Fix standard header include style

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,11 +1,11 @@
 // SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-#include "functional"
-#include "iostream"
-#include "string"
-#include "system_error"
-#include "unordered_map"
+#include <functional>
+#include <iostream>
+#include <string>
+#include <system_error>
+#include <unordered_map>
 
 #include <fmt/core.h>
 #include "common/config.h"

--- a/src/qt_gui/kbm_config_dialog.h
+++ b/src/qt_gui/kbm_config_dialog.h
@@ -6,7 +6,7 @@
 #include <QComboBox>
 #include <QDialog>
 #include <QPlainTextEdit>
-#include "string"
+#include <string>
 
 class EditorDialog : public QDialog {
 Q_OBJECT // Necessary for using Qt's meta-object system (signals/slots)

--- a/src/qt_gui/main.cpp
+++ b/src/qt_gui/main.cpp
@@ -1,9 +1,9 @@
 // SPDX-FileCopyrightText: Copyright 2024 shadPS4 Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-#include "iostream"
-#include "system_error"
-#include "unordered_map"
+#include <iostream>
+#include <system_error>
+#include <unordered_map>
 
 #include "common/config.h"
 #include "common/memory_patcher.h"

--- a/src/sdl_window.h
+++ b/src/sdl_window.h
@@ -6,7 +6,7 @@
 #include "common/types.h"
 #include "core/libraries/pad/pad.h"
 #include "input/controller.h"
-#include "string"
+#include <string>
 #define SDL_EVENT_TOGGLE_FULLSCREEN (SDL_EVENT_USER + 1)
 #define SDL_EVENT_TOGGLE_PAUSE (SDL_EVENT_USER + 2)
 


### PR DESCRIPTION
## Summary
- fix includes of standard library headers in startup code

## Testing
- `cmake -S . -B build` *(fails: does not contain a CMakeLists.txt file)*

------
https://chatgpt.com/codex/tasks/task_e_68614ba3ebe4832a9e24edc0084e69d1