### PR TITLE
Clarify Windows 10 build support

### DIFF
--- a/documents/building-windows.md
+++ b/documents/building-windows.md
@@ -10,6 +10,8 @@ If you are building to contribute to the project, please omit `--depth 1` from t
 
 Note: **ARM64 is not supported!** As of writing, it will not build nor run. The instructions with respect to ARM64 are for developers only.
 
+shadPS4 targets **Windows 10 RS5** or newer. Earlier Windows versions are not supported.
+
 ## Option 1: Visual Studio 2022
 
 ### (Prerequisite) Download the Community edition from [**Visual Studio 2022**](https://visualstudio.microsoft.com/vs/)

--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -93,6 +93,10 @@ if (NOT TARGET glslang::glslang)
     add_subdirectory(glslang)
     file(COPY glslang/SPIRV DESTINATION glslang/glslang FILES_MATCHING PATTERN "*.h")
     target_include_directories(glslang INTERFACE "${CMAKE_CURRENT_BINARY_DIR}/glslang")
+    # Prevent warnings in glslang from stopping Windows builds
+    if (MINGW)
+        target_compile_options(glslang PRIVATE -Wno-error=deprecated-copy -Wno-stringop-overflow -Wno-array-bounds)
+    endif()
 endif()
 
 # Robin-map
@@ -139,7 +143,7 @@ endif()
 
 # sirit
 add_subdirectory(sirit)
-if (WIN32)
+if (WIN32 AND CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
     target_compile_options(sirit PUBLIC "-Wno-error=unused-command-line-argument")
 endif()
 


### PR DESCRIPTION
## Summary
- mention Windows 10 RS5 requirement in the Windows build guide
- keep glslang warnings from failing MinGW builds
- only add the `-Wno-error=unused-command-line-argument` flag when using Clang

## Testing
- `cmake -S . -B build-mingw -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc -DCMAKE_CXX_COMPILER=x86_64-w64-mingw32-g++ -G Ninja -DENABLE_QT_GUI=OFF`
- `cmake --build build-mingw -j $(nproc)` *(fails: Dear_ImGui_FontEmbed.exe: Exec format error)*

------
https://chatgpt.com/codex/tasks/task_e_68614df36728832aa43a6580f2002551