### PR TITLE
Fix Android workflow

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -14,6 +14,15 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+        with:
+          packages: |
+            platform-tools
+            build-tools;34.0.0
+            platforms;android-34
+            ndk;26.2.11394342
+            cmake;3.22.1
       - name: Generate Gradle wrapper
         run: gradle -p android wrapper --gradle-version 8.2
       - name: Build APK

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -20,7 +20,10 @@ android {
     externalNativeBuild {
         cmake {
             path '../../CMakeLists.txt'
-            version '3.24'
+            // Use a CMake version provided by the Android SDK.
+            // 3.22.1 is the newest stable release available via sdkmanager
+            // and is compatible with NDK r26.
+            version '3.22.1'
         }
     }
     buildFeatures {

--- a/documents/building-android.md
+++ b/documents/building-android.md
@@ -7,7 +7,7 @@ and ARM64 (aarch64) devices.
 ## Prerequisites
 
 - Android Studio with the NDK component installed
-- CMake 3.24 or newer
+- CMake 3.22 or newer (the Android SDK ships with 3.22.1)
 
 ## Steps
 


### PR DESCRIPTION
## Summary
- update Android SDK workflow
- document correct Android CMake version
- use Android SDK CMake in Gradle configuration

## Testing
- `bash .ci/clang-format.sh` *(fails: `clang-format-19` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68615aa3bb74832ab83c1ee7d73f68f3